### PR TITLE
main.go: added exit early when both lineLimit and stmtLimit are zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 Funlen is a linter that checks for long functions. It can checks both on the number of lines and the number of statements.
 
-The default limits are 60 lines and 40 statements. You can configure these.
+## Run
+Funlen by default, requires you specify your lines or statement limits in
+order to run the scanning. Otherwise, it will skip the runs.
+
+## Default Limits
+Limits are 60 lines and 40 statements respectively when only either one is
+provided.
+
+If both limits are not provided (0,0), Funlen will skip the runs.
 
 ## Installation guide
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,13 @@ const defaultStmtLimit = 40
 
 // Run runs this linter on the provided code
 func Run(file *ast.File, fset *token.FileSet, lineLimit, stmtLimit int) []Message {
+	var msgs []Message
+
+	// exit early as we do not want to enforce opinionated 60:40 default
+	// limits onto all users
+	if lineLimit == 0 && stmtLimit == 0 {
+		return msgs
+	}
 	if lineLimit == 0 {
 		lineLimit = defaultLineLimit
 	}
@@ -19,7 +26,6 @@ func Run(file *ast.File, fset *token.FileSet, lineLimit, stmtLimit int) []Messag
 		stmtLimit = defaultStmtLimit
 	}
 
-	var msgs []Message
 	for _, f := range file.Decls {
 		decl, ok := f.(*ast.FuncDecl)
 		if !ok || decl.Body == nil { // decl.Body can be nil for e.g. cgo


### PR DESCRIPTION
funlen by current default enforces 60 lines limit and 40 statements
limit when both are not provided by user (0, 0). This forces every
users to comply to a 60 lines limit long function rule which are
not practical and very discriminative in a lot of cases. Moreover,
it broke `gitlabci-lint`'s `--enable-all` argument, which is working
fine for all other optional linters per version v1.19.1.

## DATA REASONING

Here are the exhibits for studying LOCs per functions from the most
to the least:

```
ItemNo)   LOC     Description
(Reference Source URL)
---------------------------------------------------------
1)      48229     unoptimized large test configurations generator
(http://doi.org/10.13140/RG.2.2.36308.76166, page 8)
...
2)      23746     optimized large test configurations generator
(http://doi.org/10.13140/RG.2.2.36308.76166, page 8)
...
3)        421     ed25519 ScMulAdd
(https://github.com/golang/go/blob/master/src/crypto/ed25519/internal/edwards25519/edwards25519.go#L1026)
...
4)        110     deep reflect
(https://github.com/golang/go/blob/master/src/reflect/deepequal.go#L24)
...
5)         85     ed25519 data generator
(https://github.com/golang/go/blob/master/src/crypto/ed25519/internal/edwards25519/edwards25519.go#L218)
...
6)         61     regex replace all
(https://github.com/golang/go/blob/master/src/regexp/regexp.go#L583)
...
7)         47     regex
(https://github.com/golang/go/blob/master/src/regexp/regexp.go#L169)
...
8)         43     bufio longest
(https://github.com/golang/go/blob/master/src/bufio/bufio.go#L241)
...
9)         24     average new comers' smelly codes
(https://forum.golangbridge.org/t/whats-issue-with-this-goroutine-code/15663)
...
10)        17     average new comers source codes
(https://forum.golangbridge.org/t/whats-the-issue-with-this-code/15642/23?u=hollowaykeanho)
...
11)         6     average new comers tutorial codes
(https://play.golang.org/p/RKezV69HjPe)
...
12)         3     minimum interface
(https://github.com/golang/go/blob/master/src/bufio/bufio.go#L577)
...
13)         1     hello world main
(https://play.golang.org/)
```

Based on the list of exhibits，there are multiple architectural inputs:
A) A wide varieties of users with different expertise
     A.1) Looking at a cryptography engineer item (3), its data
          generator function is visually fine and requires 421 LOCs.
     A.2) Looking at standard repository deep reflect package item(4),
          the function is clear and working fine. However, it requires
          110 LOC to represent the function.
     A.3) Looking at standard repository regex package item(7) and (8),
          the function requires 61 LOCs and 47 LOCs.
     A.4) Looking at average new comers' codes item (9) and item (10),
          the function requires 24 LOCs and 17 LOCs respectively.

B) A wide varieties of users with different experiences
     B.1) Looking at average new comers' code item (9) and item (10),
          they falls within the default 60 LOCs limits.
     B.2) Looking at cryptographer engineer item (3) and item (5),
          they both went over the default 60 LOCs limits.

C) A wide varieties of function's purposes
     C.1) Looking at item(1) for large scale test configuration data
          generator function, it requires 48229 and 23746 LOCs for
          both optimized and unoptimized version respectively.
     C.2) Looking at item(3), for crypography data generation
          function, it took 421 LOCs.
     C.3) Looking at item(13), for a hello world main function, it
          took 1 LOC.

## LEARNING

Based on (A), (B), and (C), there are 3 insights:
1. Setting a default of 60 LOCs limit discrimates a completely
   qualified NaCl cryptography engineer's expertises and the
   standard Go packages.

2. The presented LOCs ranges from 1 to 48229 based on all cases.
   Hence, it is not possible to simply guess a default limit as it
   would breaks one another such as 60 LOCs desciminates a lot
   of expert engineers while 50000 LOCs renders funlen useless for
   all cases.

3. Since each functions has its own purpose, we cannot simply
   quantify a limit as it depends on the context of the functions
   and content expertise.

## VERDICT

Therefore, we cannot enforce 60 LOCs and 40 statements limits as the
basic default operations. This encourages discrimination against
individual expertise, breaking necessity to present a function
clearly, and encourages noviceses in codes as a result. Since it
is a default value and funlen is a linter, it can be easily
assumed as an industrial practice to write functions within 60 LOCs.

As verdict, we can conclude that these limits must be **strictly**
provided by the users as he/she has the context and objective,
not quantified by a random constant number. The default response
for funlen should be adjusted back towards to requesting user's
opinionated limits instead. New comers can also learn that it is
not a mandatory practice to enforce 60 LOCs per function.

## ACTION

This patch adds an early exit when user failed to provide his/her
opinionated LOC and statement limits. The switches the default
perpectives back to funlen's fundamental objective which is to
check the functions' LOC in a non-discriminating way.

In cases where `golangci-lint` has `--enable-all` arugment without
custom settings and user failed to provide both LOCs and statements
limits, funlen skips the run instead. This aligns back to the
`--enable-all` expectations where industrial default configurations
are used.

Signed-off-by: (Holloway) Chew, Kean Ho <kean.ho.chew@zoralab.com>