### PR TITLE
Feature: Ignore comments in getLines()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ultraware/funlen
+
+go 1.20

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,57 @@
+package funlen
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestRunTable(t *testing.T) {
+	testcases := map[string]struct {
+		input     string
+		expected  string
+		lineLimit int
+		stmtLimit int
+	}{
+		"too-many-statements": {
+			input: `package main
+	func main() {
+	print("Hello, world!")
+	print("Hello, world!")}`,
+			expected:  "Function 'main' has too many statements (2 > 1)",
+			lineLimit: 1,
+			stmtLimit: 1,
+		},
+		"too-many-lines": {
+			input: `package main
+	import "fmt"
+	func main() {
+	print("main!")
+	print("is!")
+	print("too!")
+	print("long")}`,
+			expected:  "Function 'main' is too long (3 > 1)",
+			lineLimit: 1,
+			stmtLimit: 10,
+		},
+	}
+
+	for name, test := range testcases {
+		t.Run(name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "", test.input, parser.AllErrors)
+
+			if err != nil {
+				t.Error("\nActual: ", err, "\n Did not expected error")
+			}
+
+			r := Run(f, fset, test.lineLimit, test.stmtLimit)
+			actual := r[0].Message
+
+			if !strings.Contains(actual, test.expected) {
+				t.Error("\nActual: ", actual, "\nExpected: ", test.expected)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,22 @@ func TestRunTable(t *testing.T) {
 			lineLimit: 1,
 			stmtLimit: 10,
 		},
+		"too-many-statements-inline-func": {
+			input: `package main
+	func main() {
+	print("Hello, world!")
+	if true {
+		y := []int{1,2,3,4}
+		for k, v := range y {
+			f := func() { print("test") }
+			f()
+		}
+	}
+	print("Hello, world!")}`,
+			expected:  "Function 'main' has too many statements (8 > 1)",
+			lineLimit: 1,
+			stmtLimit: 1,
+		},
 	}
 
 	for name, test := range testcases {

--- a/main_test.go
+++ b/main_test.go
@@ -40,18 +40,50 @@ func TestRunTable(t *testing.T) {
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
 			fset := token.NewFileSet()
-			f, err := parser.ParseFile(fset, "", test.input, parser.AllErrors)
+			f, err := parser.ParseFile(fset, "", test.input, parser.ParseComments)
 
 			if err != nil {
 				t.Error("\nActual: ", err, "\n Did not expected error")
 			}
 
-			r := Run(f, fset, test.lineLimit, test.stmtLimit)
+			r := Run(f, fset, test.lineLimit, test.stmtLimit, false)
 			actual := r[0].Message
 
 			if !strings.Contains(actual, test.expected) {
 				t.Error("\nActual: ", actual, "\nExpected: ", test.expected)
 			}
 		})
+	}
+}
+
+func TestRunIgnoresComments(t *testing.T) {
+
+	input := `package main
+	func main() {
+	// Comment 1
+	// Comment 2
+	// Comment 3
+	print("Hello, world!")}
+	// Comment Doc
+	func unittest() {
+	// Comment 1
+	// Comment 2
+	print("Hello, world!")}
+	// Comment 3`
+
+	lineLimit := 2
+	stmtLimit := 2
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", input, parser.ParseComments)
+
+	if err != nil {
+		t.Error("\nActual: ", err, "\n Did not expected error")
+	}
+
+	r := Run(f, fset, lineLimit, stmtLimit, true)
+
+	if len(r) > 0 {
+		t.Error("\nActual: ", r, "\nExpected no lint errors")
 	}
 }


### PR DESCRIPTION
This change removes comments from being counted in `getLines()`. I also added some unittests to make sure it is acutally working.

This was acutally my first deep dive into the `go/ast` and `go/token` package, so if there's a better way, please let me know.

Fixes #12 

